### PR TITLE
Moving from Mercurial to Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 *.pyc
 *.o
 *.d


### PR DESCRIPTION
There are a few things hard-coded into hemelb that are specific to mercurial.  So far I have noticed this in `CMakeLists.txt` where `hg` is used to get the revision number and in `.hgignore` which should now be `.gitignore` (both files have the same format).  If anyone finds anything else please stick it in the `hg_to_git` branch and it will appear here.

We should probably hold off merging this until Jenkins is updated to pull from github (at least for the RBC branch - if that's the plan?).  Neither of the things I've spotted so far cause the build to break but there may be something that does.
