### PR TITLE
Setuptool: make setting iolet radius to zero non-fatal

### DIFF
--- a/Tools/setuptool/HemeLbSetupTool/Bindings/Bindings.py
+++ b/Tools/setuptool/HemeLbSetupTool/Bindings/Bindings.py
@@ -80,11 +80,13 @@ class ValueBinding(object):
             dest.Set(source.Get())
         except Translators.FormattingError:
             # Can't format this properly, so just give up for now
+            print "Warning: Could not properly format the model object for display"
             pass
-        except Translators.ValidationError:
+        except Translators.ValidationError as e:
             # We got a value from the widget (i.e. source) that
             # doesn't convert to the model requirements. Put back the
             # last known good
+            print "Warning: Could not convert input to model key %s because: %s" % (self.modelMapper.key, e.message)
             source.Set(self.modelMapper.Get())
             pass
         

--- a/Tools/setuptool/HemeLbSetupTool/Bindings/Translators.py
+++ b/Tools/setuptool/HemeLbSetupTool/Bindings/Translators.py
@@ -112,5 +112,23 @@ class FloatTranslator(Translator):
         
     pass
 
+class Constraint(Translator):
+    """Applies a constraint to the untranslated value."""
+    def __init__(self, func, inner=None):
+        """The supplied callable must accept one argument of
+        the untranslated (i.e. model side) value and return
+        True if it's OK and False if not.
+        """
+        Translator.__init__(self, inner)
+        self.func = func
+        return
 
-        
+    def TranslateStage(self, value):
+        if self.func(value):
+            return value
+        raise ValidationError('Constraint on value not satisfied')
+
+    def UntranslateStage(self, value):
+        if self.func(value):
+            return value
+        raise ValidationError('Constraint on value not satisfied')

--- a/Tools/setuptool/HemeLbSetupTool/Model/PlacedIolet.py
+++ b/Tools/setuptool/HemeLbSetupTool/Model/PlacedIolet.py
@@ -146,6 +146,7 @@ class PlacedIolet(Observable):
     Normal = property(GetNormal, SetNormal)
     
     def SetRadius(self, radius):
+        self._lastRadius = radius
         # Get into numpy vectors
         self.widget.GetCenter(self._c)
         self.widget.GetOrigin(self._o)

--- a/Tools/setuptool/HemeLbSetupTool/View/ToolPanel.py
+++ b/Tools/setuptool/HemeLbSetupTool/View/ToolPanel.py
@@ -18,7 +18,7 @@ from ..Bindings.WxMappers import WxWidgetMapper, \
      WxWidgetEnabledMapper, NonObservingWxWidgetMapper, \
      WxListCtrlMapper, WxListCtrlSelectionMapper
 from ..Bindings.Translators import NoneToValueTranslator, \
-     FloatTranslator, QuickTranslator, Translator
+     FloatTranslator, QuickTranslator, Translator, Constraint
 from ..Bindings.Bindings import WxActionBinding
 
 from ..Model.Profile import Profile
@@ -199,7 +199,7 @@ class IoletsDetailPanel(wx.Panel):
         controller.BindValue(
             'Iolets.Selection.Radius',
             WxWidgetMapper(self.radiusField, 'Value', wx.EVT_TEXT,
-                           translator=FloatTranslator())
+                           translator=Constraint(lambda x: x > 0.0, inner=FloatTranslator()))
             )
         
         self.placeButton = wx.Button(self, label='Place')


### PR DESCRIPTION
Iolet planes disappear when their radius text box is left empty and they won't reappear if a valid value is added. This is because setting the radius to zero/nan ruins all the other values and is difficult to recover from.

Instead, add constraints to the setuptool's binding infrastructure (using a translator). Also add decent error messages (to the terminal only for now).

Add a constraint to make the radius strictly positive, so it can't be invalid.
