### PR TITLE
Avoid repeated calls to MPI_Comm_size

### DIFF
--- a/Code/geometry/neighbouring/NeighbouringDataManager.cc
+++ b/Code/geometry/neighbouring/NeighbouringDataManager.cc
@@ -142,7 +142,7 @@ namespace hemelb
         hemelb::log::Logger::Log<hemelb::log::Debug, hemelb::log::OnePerCore>("NDM ShareNeeds().");
         //if (needsHaveBeenShared == true)
         //  return; //TODO: Fix!
-
+        
         // build a table of which procs needs can be achieved from which proc
         std::vector<std::vector<site_t> > needsIHaveFromEachProc(net.Size());
         std::vector<int> countOfNeedsIHaveFromEachProc(net.Size(), 0);
@@ -162,7 +162,8 @@ namespace hemelb
         net.RequestAllToAllReceive(countOfNeedsOnEachProcFromMe);
         net.Dispatch();
 
-        for (proc_t other = 0; other < net.Size(); other++)
+        const int netSize = net.Size(); // avoid calling e.g. MPI_Comm_size many times; it is not inlined
+        for (proc_t other = 0; other < netSize; other++)
         {
 
           // now, for every proc, which I need something from,send the ids of those


### PR DESCRIPTION
When using net::MpiCommunicator, net.Size() is implemented by a call to MPI_Comm_size. Using it as the upper bound in this loop actually caused it to dominate the time spent in the RequestComms phase. I noticed this reviewing some old MAP files from the ARCHER work - at 8k cores this actually consumed 12% of wall-clock time during the RunSimulation() phase. At 16k cores it took 45% of the time. This was for very short iteration timesteps but considering the simplicity of the fix and the apparent O(N^2) in #procs it'll probably manifest in production scale runs sooner or later as we continue to reach for higher scales.

This corresponds to https://github.com/UCL/hemelb/pull/1 and #664