### PR TITLE
Enable C++11 in setup tool compilation

### DIFF
--- a/Tools/setuptool/setup.py
+++ b/Tools/setuptool/setup.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
     
     libraries = []
     library_dirs = []
-    extra_compile_args = GetVtkCompileFlags(vtkLibDir) + GetHemeLbCompileFlags()
+    extra_compile_args = ['-std=c++11'] + GetVtkCompileFlags(vtkLibDir) + GetHemeLbCompileFlags()
     extra_link_args = ['-lCGAL', '-lgmp']
     
     # Create the list of extension modules


### PR DESCRIPTION
VTK 8.0 headers use C++11 features. To be able to bake them into the setup tool we need to pass `-std=c+11`