### PR TITLE
Allow CMake to build its own ParMETIS again

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -151,13 +151,14 @@ foreach(subdir ${package_subdirs})
   add_subdirectory(${subdir})
 endforeach()
 add_subdirectory(resources)
-target_link_libraries(${HEMELB_EXECUTABLE} 
+target_link_libraries(${HEMELB_EXECUTABLE} PRIVATE
   ${heme_libraries}
   ${MPI_LIBRARIES}
   ${Boost_LIBRARIES}
   )
 INSTALL(TARGETS ${HEMELB_EXECUTABLE} RUNTIME DESTINATION bin)
 list(APPEND RESOURCES resources/report.txt.ctp resources/report.xml.ctp)
+hemelb_add_target_dependency_parmetis(${HEMELB_EXECUTABLE})
 
 # ----------- HemeLB Multiscale ------------------
 if (HEMELB_BUILD_MULTISCALE)
@@ -210,7 +211,7 @@ if(HEMELB_BUILD_TESTS_ALL OR HEMELB_BUILD_TESTS_UNIT)
   hemelb_dependency(cppunit use)
   add_executable(unittests_hemelb ${root_sources})
   add_subdirectory(unittests)
-  target_link_libraries(unittests_hemelb 
+  target_link_libraries(unittests_hemelb PRIVATE
     hemelb_unittests 
     ${heme_libraries}
     ${MPI_LIBRARIES}
@@ -223,6 +224,7 @@ if(HEMELB_BUILD_TESTS_ALL OR HEMELB_BUILD_TESTS_UNIT)
     unittests/resources/velocity_inlet.txt.weights.txt
     unittests/resources/xmltest.xml unittests/resources/config_file_velocity_inlet.xml unittests/resources/velocity_inlet.txt 
     )
+  hemelb_add_target_dependency_parmetis(unittests_hemelb)
 endif()
 
 # ----------- HEMELB functionaltests ---------------
@@ -231,12 +233,13 @@ if(HEMELB_BUILD_TESTS_ALL OR HEMELB_BUILD_TESTS_FUNCTIONAL)
   hemelb_dependency(cppunit use)
   add_executable(functionaltests_hemelb ${root_sources})
   add_subdirectory(functionaltests/cpptests)
-  target_link_libraries(functionaltests_hemelb 
+  target_link_libraries(functionaltests_hemelb PRIVATE
     hemelb_functionaltests 
     ${heme_libraries}
     ${MPI_LIBRARIES}
     ${Boost_LIBRARIES})
   INSTALL(TARGETS functionaltests_hemelb RUNTIME DESTINATION bin)
+  hemelb_add_target_dependency_parmetis(functionaltests_hemelb)
 endif()
 
 #-------- Copy and install resources --------------

--- a/Code/colloids/CMakeLists.txt
+++ b/Code/colloids/CMakeLists.txt
@@ -6,15 +6,17 @@
 add_library(hemelb_colloidsBCs
   BoundaryConditions.cc
   )
-target_link_libraries(hemelb_colloidsBCs
+target_link_libraries(hemelb_colloidsBCs PRIVATE
   hemelb_io
   )
+hemelb_add_target_dependency_parmetis(hemelb_colloidsBCs)
 add_library(hemelb_colloidsForces
   BodyForces.cc
   )
-target_link_libraries(hemelb_colloidsForces
+target_link_libraries(hemelb_colloidsForces PRIVATE
   hemelb_io
   )
+hemelb_add_target_dependency_parmetis(hemelb_colloidsForces)
 add_library(hemelb_colloids
   ParticleMpiDatatypes.cc
   ParticleSet.cc
@@ -22,9 +24,10 @@ add_library(hemelb_colloids
   PersistedParticle.cc
   ColloidController.cc
   )
-target_link_libraries(hemelb_colloids
+target_link_libraries(hemelb_colloids PRIVATE
   hemelb_io
   hemelb_lb
   hemelb_colloidsForces
   hemelb_colloidsBCs
   )
+hemelb_add_target_dependency_parmetis(hemelb_colloids)

--- a/Code/extraction/CMakeLists.txt
+++ b/Code/extraction/CMakeLists.txt
@@ -8,3 +8,5 @@ add_library(hemelb_extraction GeometrySelector.cc
   IterableDataSource.cc PlaneGeometrySelector.cc PropertyActor.cc
   PropertyWriter.cc WholeGeometrySelector.cc LbDataSourceIterator.cc
   GeometrySurfaceSelector.cc SurfacePointSelector.cc)
+
+hemelb_add_target_dependency_parmetis(hemelb_extraction)

--- a/Code/lb/CMakeLists.txt
+++ b/Code/lb/CMakeLists.txt
@@ -17,3 +17,5 @@ add_library(hemelb_lb
   lattices/LatticeInfo.cc lattices/D3Q15.cc lattices/D3Q19.cc lattices/D3Q27.cc lattices/D3Q15i.cc
   MacroscopicPropertyCache.cc SimulationState.cc StabilityTester.cc
   )
+
+hemelb_add_target_dependency_parmetis(hemelb_lb)

--- a/Code/net/CMakeLists.txt
+++ b/Code/net/CMakeLists.txt
@@ -25,3 +25,5 @@ configure_file (
   "${PROJECT_SOURCE_DIR}/net/MpiConstness.h.in"
   "${PROJECT_BINARY_DIR}/net/MpiConstness.h"
   )
+
+hemelb_add_target_dependency_parmetis(hemelb_net)

--- a/Code/steering/CMakeLists.txt
+++ b/Code/steering/CMakeLists.txt
@@ -48,3 +48,5 @@ add_library(hemelb_steering
   )
 
 target_link_libraries(hemelb_steering ${CMAKE_THREAD_LIBS_INIT})
+
+hemelb_add_target_dependency_parmetis(hemelb_steering)

--- a/Code/unittests/CMakeLists.txt
+++ b/Code/unittests/CMakeLists.txt
@@ -5,3 +5,4 @@
 
 add_library(hemelb_unittests main.cc)
 hemelb_add_target_dependency_cppunit(hemelb_unittests)
+hemelb_add_target_dependency_parmetis(hemelb_unittests)

--- a/Code/vis/CMakeLists.txt
+++ b/Code/vis/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(hemelb_vis
   streaklineDrawer/NeighbouringProcessor.cc streaklineDrawer/Particle.cc streaklineDrawer/ParticleManager.cc
   streaklineDrawer/StreaklineDrawer.cc streaklineDrawer/VelocityField.cc streaklineDrawer/StreakPixel.cc
   )
+
+hemelb_add_target_dependency_parmetis(hemelb_vis)

--- a/dependencies/parmetis/find.cmake
+++ b/dependencies/parmetis/find.cmake
@@ -1,2 +1,2 @@
-find_package(Parmetis REQUIRED)
-find_package(Metis REQUIRED)
+find_package(Parmetis QUIET)
+find_package(Metis QUIET)


### PR DESCRIPTION
Following #714, CMake was unable to build its own ParMETIS. Two issues:
 * The dependencies build was aborting if it didn't find a ParMETIS system install.
 * The Code build wasn't indicating which components had ParMETIS as a dependency and therefore failing to add the right `-I` for `parmetis.h` to be found.

I have basically hit the code with a hammer until it compiled but would appreciate a CR to make sure I'm using the new CMake design (post #714) correctly.

I'm looking at you @rupertnash :) 