### PR TITLE
Red blood cells/remove rbcs inlet

### DIFF
--- a/Code/redblood/io.cc
+++ b/Code/redblood/io.cc
@@ -113,7 +113,7 @@ namespace hemelb
         }
       }
 
-      // Recongnise "fake" inlets where no cells are inserted
+      // Read physical outlets that are somehow configured as numerical inlets in the XML parameter file
       void readFlowExtensionsWithoutInsertElement(io::xml::Element const& ioletsNode,
                               util::UnitConverter const& converter,
                               std::vector<FlowExtension> &results, bool mustHaveFlowExtension =


### PR DESCRIPTION
Changes to enable the removal of cells from physical outlets that are configured as numerical inlets in the XML parameter file