### PR TITLE
#434 remove tests for std::isnan and isinf as that has been standard …

### DIFF
--- a/Code/cmake/platform_checks.cmake
+++ b/Code/cmake/platform_checks.cmake
@@ -11,8 +11,6 @@ include(intel_cpp11)
 include(CheckCXXSourceCompiles)
 include(CheckCXXSymbolExists)
 
-CHECK_CXX_SOURCE_COMPILES("#include <cmath>\n int main(int c,char** v){ return isnan(1.0); }" HAVE_ISNAN)
-CHECK_CXX_SOURCE_COMPILES("#include <cmath>\n int main(int c,char** v){ return std::isnan(1.0); }" HAVE_STD_ISNAN)
 CHECK_CXX_SOURCE_COMPILES("#include <sys/time.h>\n#include <sys/resource.h>\nint main(int c,char** v){ rusage usage;\ngetrusage(RUSAGE_SELF, &usage);\nreturn usage.ru_maxrss; }" HAVE_RUSAGE)
 
 CHECK_CXX_SOURCE_COMPILES("

--- a/Code/lb/kernels/LBGKNN.h
+++ b/Code/lb/kernels/LBGKNN.h
@@ -170,15 +170,8 @@ namespace hemelb
 						      mLbParams);
 
             // In some rheology models viscosity tends to infinity as shear rate goes to zero.
-            /// @todo: #633 refactor
-#ifdef HAVE_STD_ISNAN
             assert( (!std::isinf(localTau)) );
             assert( (!std::isnan(localTau)) );
-#endif
-#ifdef HAVE_ISNAN
-            assert( (!isinf(localTau)) );
-            assert( (!isnan(localTau)) );
-#endif
           }
       };
     }

--- a/Code/util/Bessel.cc
+++ b/Code/util/Bessel.cc
@@ -32,13 +32,7 @@ namespace hemelb
       }
 
       // If this assertion trips, it is likely that the zSqOver4_pow / (fact * fact) has become inf / inf
-      /// @todo: #633 refactor
-#ifdef HAVE_STD_ISNAN
       assert(!std::isnan(real(sum)) && !std::isnan(imag(sum)));
-#endif
-#ifdef HAVE_ISNAN
-      assert(!isnan(real(sum)) && !isnan(imag(sum)));
-#endif
 
       return sum;
     }


### PR DESCRIPTION
…since 11

Will close #434 