### PR TITLE
Fix lbb hpp loops

### DIFF
--- a/Code/lb/lb.h
+++ b/Code/lb/lb.h
@@ -50,37 +50,40 @@ namespace hemelb
         typedef typename HEMELB_WALL_INLET_BOUNDARY<collisions::Normal<LB_KERNEL> >::Type tInletWallCollision;
         typedef typename HEMELB_WALL_OUTLET_BOUNDARY<collisions::Normal<LB_KERNEL> >::Type tOutletWallCollision;
 
-        void CallDEPostStep(site_t (geometry::LatticeData::*fp)(unsigned int) const, site_t offset, const std::size_t IDX) { return; }
+        typedef site_t (geometry::LatticeData::*tCollisionCountFn)(unsigned int) const;
+
+        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX) { return; }
 
         template <typename Collision>
-        void CallDEPostStep(site_t (geometry::LatticeData::*fp)(unsigned int) const, Collision* collision, site_t offset, const std::size_t IDX)
+        void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t offset, const std::size_t IDX)
         {
-          const site_t decc = (mLatDat->*fp)(IDX);
-          PostStep(collision, offset, decc);
-          offset += decc;
+          const site_t CC = (mLatDat->*CCFP)(IDX);
+          PostStep(collision, offset, CC);
+          offset += CC;
           return;
         }
 
         template <typename Collision, typename ... Collisions >
-        void CallDEPostStep(site_t (geometry::LatticeData::*fp)(unsigned int) const, site_t offset, const std::size_t IDX, Collision* collision, Collisions* ... collisions)
+        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX, Collision* collision, 
+        Collisions* ... collisions)
         {
-          CallDEPostStep(fp, collision, offset, IDX);
-          CallDEPostStep(fp, offset, IDX+1, collisions ...);
+          CallPostStep(CCFP, collision, offset, IDX);
+          CallPostStep(CCFP, offset, IDX+1, collisions ...);
           return;
         }
 
         template <typename Tuple, std::size_t ... Is>
-        void CallDEPostStep(site_t (geometry::LatticeData::*fp)(unsigned int) const, const Tuple& COLLISIONS, site_t& offset,
+        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset,
         std::integer_sequence<std::size_t, Is...>)
         {
-          CallDEPostStep(fp, offset, 0, std::get<Is>(COLLISIONS) ...);
+          CallPostStep(CCFP, offset, 0, std::get<Is>(COLLISIONS) ...);
           return;
         }
 
         template <typename Tuple>
-        void CallDEPostStep(site_t (geometry::LatticeData::*fp)(unsigned int) const, const Tuple& COLLISIONS, site_t& offset) {
+        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset) {
           constexpr std::size_t N = std::tuple_size<Tuple>::value;
-          CallDEPostStep(fp, COLLISIONS, offset, std::make_index_sequence<N>{});
+          CallPostStep(CCFP, COLLISIONS, offset, std::make_index_sequence<N>{});
           return;
         }
 

--- a/Code/lb/lb.h
+++ b/Code/lb/lb.h
@@ -157,11 +157,11 @@ namespace hemelb
         }
 
         // base case, there are no collisions left!
-        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX) { return; }
+        void CallPostStep(const tCollisionCountFn CCFP, site_t& offset, const std::size_t IDX) { return; }
 
         // where the work takes place -- a single collision type is provided, offset is incremented by collision count
         template <typename Collision>
-        void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t offset, const std::size_t IDX)
+        void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t& offset, const std::size_t IDX)
         {
           const site_t CC = (mLatDat->*CCFP)(IDX);
           PostStep(collision, offset, CC);
@@ -171,7 +171,7 @@ namespace hemelb
 
         // picks off the front collision from the parameter pack and send it on to PostStep, sends the rest recursively
         template <typename Collision, typename ... Collisions >
-        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX, Collision* collision, 
+        void CallPostStep(const tCollisionCountFn CCFP, site_t& offset, const std::size_t IDX, Collision* collision, 
         Collisions* ... collisions)
         {
           CallPostStep(CCFP, collision, offset, IDX);

--- a/Code/lb/lb.h
+++ b/Code/lb/lb.h
@@ -18,6 +18,8 @@
 #include "reporting/Timers.h"
 #include "lb/BuildSystemInterface.h"
 #include <typeinfo>
+#include <tuple>
+#include <utility>
 
 namespace hemelb
 {
@@ -47,6 +49,40 @@ namespace hemelb
         // And again but for sites that are both in-/outlet and wall
         typedef typename HEMELB_WALL_INLET_BOUNDARY<collisions::Normal<LB_KERNEL> >::Type tInletWallCollision;
         typedef typename HEMELB_WALL_OUTLET_BOUNDARY<collisions::Normal<LB_KERNEL> >::Type tOutletWallCollision;
+
+        void CallDEPostStep(site_t offset, const std::size_t IDX) { return; }
+
+        template <typename Collision>
+        void CallDEPostStep(Collision* collision, site_t offset, const std::size_t IDX)
+        {
+          const site_t decc = mLatDat->GetDomainEdgeCollisionCount(IDX);
+          PostStep(collision, offset, decc);
+          offset += decc;
+          return;
+        }
+
+        template <typename Collision, typename ... Collisions >
+        void CallDEPostStep(site_t offset, const std::size_t IDX, Collision* collision, Collisions* ... collisions)
+        {
+          CallDEPostStep(collision, offset, IDX);
+          CallDEPostStep(offset, IDX+1, collisions ...);
+          return;
+        }
+
+        template <typename Tuple, std::size_t ... Is>
+        void CallDEPostStep(const Tuple& COLLISIONS, site_t& offset,
+        std::integer_sequence<std::size_t, Is...>)
+        {
+          CallDEPostStep(offset, 0, std::get<Is>(COLLISIONS) ...);
+          return;
+        }
+
+        template <typename Tuple>
+        void CallDEPostStep(const Tuple& COLLISIONS, site_t& offset) {
+          constexpr std::size_t N = std::tuple_size<Tuple>::value;
+          CallDEPostStep(COLLISIONS, offset, std::make_index_sequence<N>{});
+          return;
+        }
 
       public:
         /**

--- a/Code/lb/lb.h
+++ b/Code/lb/lb.h
@@ -156,8 +156,10 @@ namespace hemelb
           }
         }
 
+        // base case, there are no collisions left!
         void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX) { return; }
 
+        // where the work takes place -- a single collision type is provided, offset is incremented by collision count
         template <typename Collision>
         void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t offset, const std::size_t IDX)
         {
@@ -167,6 +169,7 @@ namespace hemelb
           return;
         }
 
+        // picks off the front collision from the parameter pack and send it on to PostStep, sends the rest recursively
         template <typename Collision, typename ... Collisions >
         void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX, Collision* collision, 
         Collisions* ... collisions)
@@ -176,6 +179,7 @@ namespace hemelb
           return;
         }
 
+        // turns the tuple in to a parameter pack which is provided to the variadic form of CallPostStep
         template <typename Tuple, std::size_t ... Is>
         void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset,
         std::integer_sequence<std::size_t, Is...>)
@@ -184,6 +188,7 @@ namespace hemelb
           return;
         }
 
+        // entry point -- creates a compile-time sequence of indexes which are used to unpack the tuple
         template <typename Tuple>
         void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset) {
           constexpr std::size_t N = std::tuple_size<Tuple>::value;

--- a/Code/lb/lb.h
+++ b/Code/lb/lb.h
@@ -52,41 +52,6 @@ namespace hemelb
 
         typedef site_t (geometry::LatticeData::*tCollisionCountFn)(unsigned int) const;
 
-        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX) { return; }
-
-        template <typename Collision>
-        void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t offset, const std::size_t IDX)
-        {
-          const site_t CC = (mLatDat->*CCFP)(IDX);
-          PostStep(collision, offset, CC);
-          offset += CC;
-          return;
-        }
-
-        template <typename Collision, typename ... Collisions >
-        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX, Collision* collision, 
-        Collisions* ... collisions)
-        {
-          CallPostStep(CCFP, collision, offset, IDX);
-          CallPostStep(CCFP, offset, IDX+1, collisions ...);
-          return;
-        }
-
-        template <typename Tuple, std::size_t ... Is>
-        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset,
-        std::integer_sequence<std::size_t, Is...>)
-        {
-          CallPostStep(CCFP, offset, 0, std::get<Is>(COLLISIONS) ...);
-          return;
-        }
-
-        template <typename Tuple>
-        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset) {
-          constexpr std::size_t N = std::tuple_size<Tuple>::value;
-          CallPostStep(CCFP, COLLISIONS, offset, std::make_index_sequence<N>{});
-          return;
-        }
-
       public:
         /**
          * Constructor, stage 1.
@@ -189,6 +154,41 @@ namespace hemelb
           {
             collision->template DoPostStep<false> (iFirstIndex, iSiteCount, &mParams, mLatDat, propertyCache);
           }
+        }
+
+        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX) { return; }
+
+        template <typename Collision>
+        void CallPostStep(const tCollisionCountFn CCFP, Collision* collision, site_t offset, const std::size_t IDX)
+        {
+          const site_t CC = (mLatDat->*CCFP)(IDX);
+          PostStep(collision, offset, CC);
+          offset += CC;
+          return;
+        }
+
+        template <typename Collision, typename ... Collisions >
+        void CallPostStep(const tCollisionCountFn CCFP, site_t offset, const std::size_t IDX, Collision* collision, 
+        Collisions* ... collisions)
+        {
+          CallPostStep(CCFP, collision, offset, IDX);
+          CallPostStep(CCFP, offset, IDX+1, collisions ...);
+          return;
+        }
+
+        template <typename Tuple, std::size_t ... Is>
+        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset,
+        std::integer_sequence<std::size_t, Is...>)
+        {
+          CallPostStep(CCFP, offset, 0, std::get<Is>(COLLISIONS) ...);
+          return;
+        }
+
+        template <typename Tuple>
+        void CallPostStep(const tCollisionCountFn CCFP, const Tuple& COLLISIONS, site_t& offset) {
+          constexpr std::size_t N = std::tuple_size<Tuple>::value;
+          CallPostStep(CCFP, COLLISIONS, offset, std::make_index_sequence<N>{});
+          return;
         }
 
         unsigned int inletCount;

--- a/Code/lb/lb.hpp
+++ b/Code/lb/lb.hpp
@@ -288,28 +288,16 @@ namespace hemelb
         mOutletCollision, mInletWallCollision, mOutletWallCollision
       };
 
+      const tCollisionCountFn DECCFP = &geometry::LatticeData::GetDomainEdgeCollisionCount;
+      const tCollisionCountFn MDCCFP = &geometry::LatticeData::GetMidDomainCollisionCount;
+
       timings[hemelb::reporting::Timers::lb_calc].Start();
 
-      CallDEPostStep(&geometry::LatticeData::GetDomainEdgeCollisionCount, COLLISIONS, offset);
+      CallPostStep(DECCFP, COLLISIONS, offset);
 
       offset = 0;
 
-      PostStep(mMidFluidCollision, offset, mLatDat->GetMidDomainCollisionCount(0));
-      offset += mLatDat->GetMidDomainCollisionCount(0);
-
-      PostStep(mWallCollision, offset, mLatDat->GetMidDomainCollisionCount(1));
-      offset += mLatDat->GetMidDomainCollisionCount(1);
-
-      PostStep(mInletCollision, offset, mLatDat->GetMidDomainCollisionCount(2));
-      offset += mLatDat->GetMidDomainCollisionCount(2);
-
-      PostStep(mOutletCollision, offset, mLatDat->GetMidDomainCollisionCount(3));
-      offset += mLatDat->GetMidDomainCollisionCount(3);
-
-      PostStep(mInletWallCollision, offset, mLatDat->GetMidDomainCollisionCount(4));
-      offset += mLatDat->GetMidDomainCollisionCount(4);
-
-      PostStep(mOutletWallCollision, offset, mLatDat->GetMidDomainCollisionCount(5));
+      CallPostStep(MDCCFP, COLLISIONS, offset);
 
       timings[hemelb::reporting::Timers::lb_calc].Stop();
       timings[hemelb::reporting::Timers::lb].Stop();

--- a/Code/lb/lb.hpp
+++ b/Code/lb/lb.hpp
@@ -12,6 +12,7 @@
 #include "util/unique.h"
 #include "lb/InitialCondition.h"
 #include "lb/InitialCondition.hpp"
+#include <tuple>
 
 namespace hemelb
 {
@@ -280,25 +281,16 @@ namespace hemelb
       // Do any cleanup steps necessary on boundary nodes
       site_t offset = mLatDat->GetMidDomainSiteCount();
 
+      const std::tuple<tMidFluidCollision*, tWallCollision*, tInletCollision*,
+      tOutletCollision*, tInletWallCollision*, tOutletWallCollision*> 
+      COLLISIONS {
+        mMidFluidCollision, mWallCollision, mInletCollision,
+        mOutletCollision, mInletWallCollision, mOutletWallCollision
+      };
+
       timings[hemelb::reporting::Timers::lb_calc].Start();
 
-      //TODO yup, this is horrible. If you read this, please improve the following code.
-      PostStep(mMidFluidCollision, offset, mLatDat->GetDomainEdgeCollisionCount(0));
-      offset += mLatDat->GetDomainEdgeCollisionCount(0);
-
-      PostStep(mWallCollision, offset, mLatDat->GetDomainEdgeCollisionCount(1));
-      offset += mLatDat->GetDomainEdgeCollisionCount(1);
-
-      PostStep(mInletCollision, offset, mLatDat->GetDomainEdgeCollisionCount(2));
-      offset += mLatDat->GetDomainEdgeCollisionCount(2);
-
-      PostStep(mOutletCollision, offset, mLatDat->GetDomainEdgeCollisionCount(3));
-      offset += mLatDat->GetDomainEdgeCollisionCount(3);
-
-      PostStep(mInletWallCollision, offset, mLatDat->GetDomainEdgeCollisionCount(4));
-      offset += mLatDat->GetDomainEdgeCollisionCount(4);
-
-      PostStep(mOutletWallCollision, offset, mLatDat->GetDomainEdgeCollisionCount(5));
+      CallDEPostStep(COLLISIONS, offset);
 
       offset = 0;
 

--- a/Code/lb/lb.hpp
+++ b/Code/lb/lb.hpp
@@ -290,7 +290,7 @@ namespace hemelb
 
       timings[hemelb::reporting::Timers::lb_calc].Start();
 
-      CallDEPostStep(COLLISIONS, offset);
+      CallDEPostStep(&geometry::LatticeData::GetDomainEdgeCollisionCount, COLLISIONS, offset);
 
       offset = 0;
 


### PR DESCRIPTION
Closes #25 :
I thought I'd see what the oldest open issue was -- this is one way to close it.  I avoided dealing with not having a pointer a base class for collision objects, by packing them up in to a tuple. The price is a set of recursive function calls to pack them back up.

To be honest I think the original code was fine, so I suggest we either accept this and close #25, or close as wontfix!

I have just noticed that this seemed to pass unit tests even when offset wasn't being passed down by reference, so if someone could test on an example which should fail if it's wrong I'd appreciate it... (Or send me the input files for a case that should fail!)

Edit: Rupert has given me access to hemelb-test, so can test myself 👍 