### PR TITLE
Make use of Boost_INCLUDE_DIR and function template

### DIFF
--- a/Code/lb/streamers/NashZerothOrderPressureDelegate.h
+++ b/Code/lb/streamers/NashZerothOrderPressureDelegate.h
@@ -39,7 +39,7 @@ namespace hemelb
             distribn_t ghostDensity = iolet.GetBoundaryDensity(boundaryId);
 
             // Calculate the velocity at the ghost site, as the component normal to the iolet.
-	    auto ioletNormal = iolet.GetLocalIolet(boundaryId)->GetNormal().as<float>();
+	    auto ioletNormal = iolet.GetLocalIolet(boundaryId)->GetNormal().template as<float>();
 
             // Note that the division by density compensates for the fact that v_x etc have momentum
             // not velocity.

--- a/Code/redblood/CMakeLists.txt
+++ b/Code/redblood/CMakeLists.txt
@@ -66,4 +66,6 @@ else()
     RBCConfig.cc
     FlowExtension.cc
     )
+  target_link_libraries(hemelb_redblood PRIVATE
+    Boost::boost)
 endif()


### PR DESCRIPTION
Two points:
 * I tried an installation with all the dependencies but ParMETIS provided by Homebrew and I need to make use of Boost_INCLUDE_DIR. Is this the right place to put it?
 * I need to help my Clang 13.0 with a function template. Is it more picky with the standard than others or is it not compiling against the right version of it (`-std=gnu++14` from what I can see).
