### PR TITLE
Fix Doc README Link for XML Config

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ A typical workflow with HemeLB consists of four steps:
 
 2. Setting options in the configuration XML file, such as timestep and
    output data and
-   frequency. [Documentation](users/XmlConfiguration.md)
+   frequency. [Documentation](user/XmlConfiguration.md)
 
 3. Compiling and running the
    [main application](user/main-application.md).


### PR DESCRIPTION
### Summary
The link directing to the Xml Configuration readme is broken on the doc/readme.md file as it's path mistakenly points to a "users" folder rather than the "user" folder.
This small change will fix the link 

### Test plan
Confirmed link points to correct location 