### PR TITLE
gmy-tool: remove setting STL file from CLI command line

### DIFF
--- a/geometry-tool/HlbGmyTool/scripts/cli.py
+++ b/geometry-tool/HlbGmyTool/scripts/cli.py
@@ -20,13 +20,6 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "--stl",
-    default=None,
-    dest="StlFile",
-    help="The STL file to use as input",
-    metavar="PATH",
-)
-parser.add_argument(
     "--geometry",
     default=None,
     dest="OutputGeometryFile",


### PR DESCRIPTION
Because a pr2 file needs to specify iolet locations etc it makes no sense to allow resetting the STL file from the CLI command line. If one does so, it recalculates the voxel size which then messes up the rest (this caught out a user)

Remove the option.