### PR TITLE
Improve user and developer documentation, add DARWIN support, and configure MkDocs/readthedocs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ Tools/GenerateStl
 _skbuild
 dist
 .vagrant
+
+hemelb-experiments/*
+hemelb-scripts/*
+papers/*
+outputs/*
+.cache

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+# Build documentation with Mkdocs
+mkdocs:
+   configuration: doc/mkdocs.yml
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - requirements: doc/mkdocs-requirements.txt

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Key publications:
   complex domains", Phys. Rev. E (2014).
   https://doi.org/10.1103/PhysRevE.89.023303
 
-Please see the [doc] folder for more details.
+Please see the [doc](./doc/) folder for more details.

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Key publications:
   complex domains", Phys. Rev. E (2014).
   https://doi.org/10.1103/PhysRevE.89.023303
 
-Please see the [doc](./doc/) folder for more details.
+Please see the [doc](./doc/) folder or [here](https://hemelb.readthedocs.io/en/docs/) for more details.

--- a/doc/404.md
+++ b/doc/404.md
@@ -1,0 +1,10 @@
+# Page Not Found
+
+![Rest here, weary traveler](https://i.kym-cdn.com/photos/images/newsfeed/002/336/753/653.gif)
+
+**Rest Here, Weary Traveler, For Great Adventures Lie Ahead**
+
+---
+
+It appears you have wandered off the path.  
+Try using the navigation or [return to the homepage](README.md).

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,18 +6,18 @@ A typical workflow with HemeLB consists of four steps:
    use extension .gmy) from a representation of the surface of your
    domain. For this, you need to use the application in the
    [geometry-tool](../geometry-tool)
-   directory. [Documentation](user/geometry-tool.md)
+   directory. [Documentation](./user/geometry-tool.md)
 
 2. Setting options in the configuration XML file, such as timestep and
    output data and
-   frequency. [Documentation](user/XmlConfiguration.md)
+   frequency. [Documentation](./user/XmlConfiguration.md)
 
 3. Compiling and running the
-   [main application](user/main-application.md).
+   [main application](./user/main-application.md).
 
 4. Post processing the results, using the Python packages in the
-   [python-tools](../python-tools) directory. [Documentation](user/python-tools.md)
+   [python-tools](../python-tools) directory. [Documentation](./user/python-tools.md)
 
 
-[Developer documentation](dev)
+[Developer documentation](./dev)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,7 @@ A typical workflow with HemeLB consists of four steps:
 4. Post processing the results, using the Python packages in the
    [python-tools](../python-tools) directory. [Documentation](./user/python-tools.md)
 
+You can get started following our [quick-start tutorial](./user/quick-start.md).
 
 [Developer documentation](./dev)
 

--- a/doc/mkdocs-requirements.txt
+++ b/doc/mkdocs-requirements.txt
@@ -1,0 +1,3 @@
+mkdocs-material
+pymdown-extensions
+mkdocs-git-revision-date-localized-plugin

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: HemeLB Documentation
+repo_url: https://github.com/hemelb-codes/hemelb
+repo_name: hemelb-codes/hemelb
+docs_dir: .  # Current directory (doc/) 
+nav:
+  - Home: README.md
+
+  - Dev:
+      - File Formats:
+          - Extraction: dev/file-formats/extraction.md
+          - Geometry: dev/file-formats/geometry.md
+          - Offset: dev/file-formats/offset.md
+          - Old Geometry: dev/file-formats/old-geometry.md
+
+      - Formats:
+          - Geometry: dev/formats/Geometry.md   
+
+  - User:
+      - Main Application: user/main-application.md
+      - CMake Options: user/CMakeOptions.md
+      - Geometry Tool: user/geometry-tool.md
+      - Non-Cylindrical Inlets: user/non-cylindrical-velocity-inlets.md
+      - Python Tools: user/python-tools.md
+      - XML Configuration: user/XmlConfiguration.md
+      - Machine-Specific Build Notes:
+          - ARCHER2: user/machine-specific-build-notes/archer2.md
+
+
+theme:
+  # name: readthedocs  # Default styling
+  logo: https://github.com/lepotatoguy/lepotatoguy.github.io/blob/main/hemelb/images/hemelb.png?raw=true
+  favicon: https://github.com/lepotatoguy/lepotatoguy.github.io/blob/main/hemelb/images/hemelb.png?raw=true
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.sections
+    - toc.integrate
+    - search.suggest
+    - search.highlight
+    - content.code.annotate
+    - content.code.copy  
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+
+plugins:
+    - search
+    - git-revision-date-localized
+
+markdown_extensions:
+    - admonition
+    - attr_list
+    - toc:
+        permalink: true
+    - pymdownx.superfences
+    - pymdownx.highlight
+    - pymdownx.inlinehilite
+    - pymdownx.details
+    - pymdownx.mark
+    - pymdownx.emoji
+    - pymdownx.tabbed
+    - pymdownx.tasklist

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
           - Geometry: dev/formats/Geometry.md   
 
   - User:
+      - Quick Start: user/quick-start.md
       - Main Application: user/main-application.md
       - CMake Options: user/CMakeOptions.md
       - Geometry Tool: user/geometry-tool.md

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - XML Configuration: user/XmlConfiguration.md
       - Machine-Specific Build Notes:
           - ARCHER2: user/machine-specific-build-notes/archer2.md
+          - DARWIN: user/machine-specific-build-notes/darwin.md
 
 
 theme:

--- a/doc/user/CMakeOptions.md
+++ b/doc/user/CMakeOptions.md
@@ -75,7 +75,7 @@ by setting these options.
   `HEMELB_INLET_BOUNDARY` and `HEMELB_OUTLET_BOUNDARY` respectively from
   NASHZEROTHORDERPRESSUREIOLET (default), LADDIOLET. It is *very
   important* that you also select `HEMELB_WALL_INLET_BOUNDARY` and
-  `HEMELB_WALL_INLET_BOUNDARY` to match the combination of your
+  `HEMELB_WALL_OUTLET_BOUNDARY` to match the combination of your
   selected wall and in/outlet boundaries. (Options are:
   NASHZEROTHORDERPRESSURESBB, NASHZEROTHORDERPRESSUREBFL, LADDIOLETSBB,
   LADDIOLETBFL)

--- a/doc/user/XmlConfiguration.md
+++ b/doc/user/XmlConfiguration.md
@@ -87,9 +87,9 @@ The `<geometry>` element is required. It has one, required, child element:
         * `<velocity value="velocity" units="m/s" />`
         * `<label value="multiscale_label_string" />`
     * `type="velocity"`
-      * `subtype="parabolic"` - Poiseuille flow in a cylinder, i.e. parabolic
-		* `<radius value="float" units="lattice" />` -  radius of tube (in lattice units)
-		* `<maximum value="float" units="lattice">` -  maximum velocity (in lattice units)
+      * `subtype="parabolic"` - Poiseuille flow in a cylinder, i.e. parabolic. **Note:** When using this, HemeLB needs be compiled with proper flag (i.e. `HEMELB_INLET_BOUNDARY=LADDIOLET`). Otherwise, the simulation will result in a runtime error.
+		* `<radius value="float" units="m" />` -  radius of tube
+		* `<maximum value="m/s" units="lattice">` -  maximum velocity
 	  * `subtype="womersley"`
 		* `<womersley_velocity>` - a Womersley flow in a cylinder
 		* `<pressure_gradient_amplitude value="float" units="lattice"/>`

--- a/doc/user/XmlConfiguration.md
+++ b/doc/user/XmlConfiguration.md
@@ -101,7 +101,7 @@ The `<geometry>` element is required. It has one, required, child element:
         * `<radius value="float" units="lattice"/>` or `<radius value="float" units="m"/>`
 
 ## Outlets
-As for "inlets" but with `s/inlet/outlet/`
+Similar to the parameters of "inlets" but substitute with outlet or use the command `s/inlet/outlet/`.
 
 ## Initial Conditions
 `<initialconditions>` - describe initial conditions. Child elements:

--- a/doc/user/geometry-tool.md
+++ b/doc/user/geometry-tool.md
@@ -107,7 +107,7 @@ python macos-fix-gui-launcher.py
 ## Install with custom VMTK
 
 The hemelb-codes organisation on GitHub includes a project to build
-VMTK  for Ubuntu: https://github.com/hemelb-codes/vmtk-build/
+VMTK for Ubuntu: https://github.com/hemelb-codes/vmtk-build/
 
 That will hopefully give you an idea for how to proceed. If you are
 lucky you can just download the tarball. (Some Ubuntu packages will
@@ -139,7 +139,7 @@ $ hlb-gmy-gui --help
 usage: hlb-gmy-gui [-h] [--profile PATH] [--stl PATH] [--geometry PATH]
                    [--xml PATH]
 
-Process an input STL file intosuitable input for HemeLB.
+Process an input STL file into suitable input for HemeLB.
 
 optional arguments:
   -h, --help       show this help message and exit
@@ -150,16 +150,33 @@ optional arguments:
   --xml PATH       XML output file
 ```
 
-The terminal will produced a few errors that can ignore, like:
-`vtkSTLReader (0x7fdaa773bf10): A FileName must be specified.`. (This
-is just VTK trying to display the mesh before the source file is
-specified.)
+The terminal will produce a few errors that can ignore, like: `vtkSTLReader (0x7fdaa773bf10): A FileName must be specified.` (This is just VTK trying to display the mesh before the source file is specified.) and `vtkCompositeDataPipeline (0x2fb7b9a0): UpdateInformation invoked during another request.  Returning failure to algorithm vtkSTLReader(0x2f740e60).` (This is just vtkSTLReader was called during another operation, but rendering works as the STL gets loaded and cached beforehand).
+
+## Run CLI
+
+There is a command line version of Geometry Setup Tool, where you can use the .pr2 file to generate the geometry file. 
+Ensure your environment is activated then run `hlb-gmy-cli`. There is basic command line help available:
+
+```
+$ hlb-gmy-cli --help
+usage: hlb-gmy-cli [-h] [--geometry PATH] [--xml PATH] [--voxel FLOAT] PATH
+Generate the config file described by a profile file
+positional arguments:
+  PATH             The profile to use. Other options given override those in
+                   the profile file.
+optional arguments:
+  -h, --help       show this help message and exit
+  --geometry PATH  Config output file
+  --xml PATH       XML output file
+  --voxel FLOAT    The voxel size in metres
+```
+
+You need to add the path to the directory of the .pr2 file. Example command: `hlb-gmy-cli /path-to-your-profile.pr2`. *Note: The .stl file related to the .pr2 file needs to be in the same directory alongwith it.*
 
 
 ## Profile (.pr2) files
 
-The geometry tool can store the the data it will use to generate a
-geometry file. Saving this is highly recommended for reproducibility!
+The geometry tool can save inlet, outlet, and seed point data used to generate a .gmy geometry file, using this Profile file. **(Saving this is highly recommended for reproducibility)**
 
 It's a YAML file which can be edited manually. Floating point values
 are stored by default in hexadecimal to avoid precision loss

--- a/doc/user/machine-specific-build-notes/darwin.md
+++ b/doc/user/machine-specific-build-notes/darwin.md
@@ -1,0 +1,24 @@
+# Building on DARWIN
+
+[DARWIN, University of Delaware HPC](https://docs.hpc.udel.edu/abstract/darwin/darwin)
+
+Author: [Dr. Ulf Schiller](https://github.com/uschille)
+
+```
+SW_DIR=${HOME}/sw
+HEMELB_SRC_DIR=${SW_DIR}/hemelb/src
+HEMELB_BUILD_DIR=${SW_DIR}/hemelb/build
+HEMELB_INSTALL_DIR=${SW_DIR}/hemelb
+WORKGROUP=your-workgroup-name-here
+WORKDIR=$(workgroup -g ${WORKGROUP} --command 'echo ${WORKDIR}')
+workgroup -g ${WORKGROUP} --command @ -- srun --partition=idle sh -s << EOF
+vpkg_require cmake/3.28.3 gcc/14.2.0 openmpi/5.0.2 git/2.34.1
+git clone git@github.com:hemelb-codes/hemelb.git ${HEMELB_SRC_DIR}
+mkdir -p ${HEMELB_BUILD_DIR}
+pushd ${HEMELB_BUILD_DIR}
+cmake -D CMAKE_C_COMPILER=/opt/shared/gcc/14.2.0/bin/gcc -D CMAKE_CXX_COMPILER=/opt/shared/gcc/14.2.0/bin/g++ -D CMAKE_INSTALL_PREFIX=${HEMELB_INSTALL_DIR} -D HEMELB_DEPENDENCIES_INSTALL_PREFIX=${WORKDIR}/sw ${HEMELB_SRC_DIR}
+make
+popd
+${HEMELB_INSTALL_DIR}/bin/hemelb-tests
+EOF
+```

--- a/doc/user/python-tools.md
+++ b/doc/user/python-tools.md
@@ -32,7 +32,7 @@ Available command line tools:
 
 - `hlb-gmy-compress`: compress an uncompressed geometry file.
 
-- `hlb-dump-extracted-properties`: convert an extraction file to CSV.
+- `hlb-dump-extracted-properties`: convert an extraction file (.xtr) to CSV. (Note: You may find another library HemeXtract, to be mentioned online for this, however, please note that it was developed for a fork of HemeLB and is not compatible with this version. So, instead of that, please use this to convert extraction files to CSV.)
 
 - `hlb-gmy-selfconsistent`: check if a geometry file is self-consistent.
 

--- a/doc/user/quick-start.md
+++ b/doc/user/quick-start.md
@@ -1,0 +1,112 @@
+
+# Quickstart
+
+This guide walks you through running a HemeLB simulation, and extracting simulation results on a Debian-based Linux machine. 
+
+---
+
+Assuming you already installed HemeLB and created HemeLB Geometry Tool environment and Python Tool environment. 
+
+---
+
+## 0. (Optional) Example File
+
+If you want to use example files to get started, you can find it at `geometry-tool/tests/Model/data/`. 
+
+---
+
+## 1. Generate Geometry Files from STL
+
+First of all, create your STL file of your intended geometry that you want to work on. Then you can use either GUI (preferable if you are using first time) or CLI (if you already have related files). 
+
+Then activate the python environment where you installed the [geometry-tool](./geometry-tool.md).
+
+### GUI:
+```bash
+hlb-gmy-gui --stl your_geometry.stl
+```
+
+You may face two errors in the command line (please refer [here](./geometry-tool.md) to know more), which you can ignore.
+
+Then, 
+
+- Mark inlets/outlets
+- Set voxel size and seed point
+- Click *Generate*
+- [Optional] Save profile (`.pr2`)
+
+### CLI:
+
+If you have the profile (`.pr2`) file, and related STL file, you can use the command.
+
+```bash
+hlb-gmy-cli your_profile.pr2
+```
+
+Please ensure to keep the `.stl` file in the same directory or wherever it is referred inside the profile file.
+
+If successfully executed, you will get something like this below:
+
+```
+Succesfully created closed polygon from input
+The polyhedron has 160 facets 480 halfedges 0 border halfedges 82 vertices 
+Preprocessing took: 0.000318 s 
+Setup time: 0.198797 s
+```
+
+You should get your `.gmy` and `.xml` file after this. 
+
+---
+
+## 2. Prepare XML Configuration
+
+Ensure your `input.xml` includes this below, to get your output file:
+
+```xml
+<properties>
+  <propertyoutput file="whole.xtr" period="100">
+    <geometry type="whole"/>
+    <field type="velocity"/>
+    <field type="pressure"/>
+    <!-- You can also add more field types, please refer to XmlConfiguration.md for more. -->
+  </propertyoutput>
+</properties>
+```
+
+---
+
+## 3. Run the Simulation
+
+Now, run the command
+
+```bash
+mpirun -n number_of_processes hemelb -in input.xml -out ./output/
+```
+
+Here, you can put 1 (slower) or more (faster) as the number_of_processes. (For test file, 1 is enough)
+
+After this, you should see result something like this below.
+
+```
+![1.3s]time step 2700
+![1.4s]time step 2800
+![1.4s]time step 2900
+![1.5s]time step 3000
+![1.5s]Finish running simulation.
+```
+
+If you do: Congratulations! You have successfully simulated using HemeLB. 
+
+---
+
+## 4. Post-Processing
+
+You will get output files in `output` folder (based on previous command) and you can get `whole.xtr` file from there, which contains simulation output of your geometry. Afterwards, activate your python environment in which you installed the [python-tools](./python-tools.md). Then use the command below to convert `.xtr` output to a human readable `.csv` file:
+
+```bash
+hlb-dump-extracted-properties whole.xtr > whole.csv
+```
+
+After you get the CSV, you can view the results using your preferred tool (e.g., ParaView or Python).
+
+---

--- a/geometry-tool/.vagrant-provision-ubuntu-20.04.sh
+++ b/geometry-tool/.vagrant-provision-ubuntu-20.04.sh
@@ -28,4 +28,4 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # Allow non-root to run GUI
 echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
 # NOTE: VM requires reboot before running GUI
-echo "Before using the GUI run `vagrant reload gmy`
+echo "Before using the GUI run \`vagrant reload gmy\`"

--- a/geometry-tool/HlbGmyTool/Model/Generation/PolyDataGenerator.cpp
+++ b/geometry-tool/HlbGmyTool/Model/Generation/PolyDataGenerator.cpp
@@ -184,7 +184,7 @@ void PolyDataGenerator::CreateCGALPolygon(void) {
     throw GenerationErrorMessage(
         "Created surface is not valid, cannot voxelize.");
   } else {
-    cout << "Succesfully created closed polygon from input" << endl;
+    cout << "Successfully created closed polygon from input" << endl;
     cout << "The polyhedron has " << ClippedCGALSurface->size_of_facets()
          << " facets " << ClippedCGALSurface->size_of_halfedges()
          << " halfedges " << ClippedCGALSurface->size_of_border_halfedges()


### PR DESCRIPTION
I updated the documentation system and documentation content:

### 1. Fixed typos here and there.

### 2. Documentation Enhancements
- **Relative link corrections** throughout the documentation.
- **Updated sections** in `README.md` and `XmlConfiguration.md`, including:
  - Runtime flags for parabolic inlet types
  - GUI runtime warnings for VTK users
  - CLI usage for geometry file generation
- **Added notes on tool compatibility**, e.g., clarified that HemeXtract is not compatible with this HemeLB build.
- **Added DARWIN machine-specific build guide** at `doc/user/machine-specific-build-notes/darwin.md`, detailing build instructions for the University of Delaware HPC system named DARWIN.
-  **Added quickstart for new users** at `doc/user/quick-start.md`.

### 3. ReadTheDocs Website Configuration
- Added `mkdocs.yml`, `mkdocs-requirements.txt`, `.readthedocs.yaml` for Read the Docs integration.
- Included a custom 404 page for improved navigation UX.

The documentation is now available at https://hemelb.readthedocs.io/en/docs/. 

Upon merge of this PR, I intend to transfer the Read the Docs configuration access to a core maintainer to support long-term maintainability. Please note that the current Read the Docs project is linked to my personal fork.

Please advise if further changes are needed. Thanks.